### PR TITLE
Lazyblob isolation

### DIFF
--- a/cli/lazyblob/lazyblob_test.go
+++ b/cli/lazyblob/lazyblob_test.go
@@ -43,9 +43,8 @@ func TestLazyblob(t *testing.T) {
 	r.NoError(err)
 	r.True(strings.HasSuffix(fn, ".rpm.tmp"))
 
-	fp, err := lb.File(ctx)
+	fp, err := lb.Reader(ctx)
 	r.NoError(err)
-	defer fp.Close()
 
 	data, err := io.ReadAll(fp)
 	r.NoError(err)

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -222,14 +222,12 @@ func (s *service) createVersionFromYUMRepository(ctx context.Context, containerN
 
 			if uploadURL := resp.GetUploadUrl(); uploadURL != "" {
 				if gpgKeyring != nil {
-
 					log.Debug("verifying RPM GPG signature ...")
 
-					fp, err := lb.File(ctx)
+					fp, err := lb.Reader(ctx)
 					if err != nil {
 						return errors.Wrap(err, "error opening package file")
 					}
-					defer fp.Close()
 
 					_, sigs, err := rpmutils.Verify(fp, gpgKeyring)
 					if err != nil {
@@ -244,11 +242,10 @@ func (s *service) createVersionFromYUMRepository(ctx context.Context, containerN
 				err := func(url, uploadURL string) error {
 					log.Tracef("Upload URL: `%s`", uploadURL)
 
-					fp, err := lb.File(ctx)
+					fp, err := lb.Reader(ctx)
 					if err != nil {
 						return errors.Wrap(err, "error opening package file")
 					}
-					defer fp.Close()
 
 					return uploadBlob(ctx, uploadURL, fp, size)
 				}(url, uploadURL)

--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -386,12 +386,7 @@ func (s *service) CreateObject(containerName, versionID, directoryPath string) f
 				}
 				defer fp.Close()
 
-				buf := bytes.NewBuffer(nil)
-				if _, err := io.Copy(buf, fp); err != nil {
-					return errors.Wrap(err, "error on data copy")
-				}
-
-				if err := uploadBlob(ctx, url, buf, size); err != nil {
+				if err := uploadBlob(ctx, url, fp, size); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
- Limit `*os.File` interface to `io.Reader` only to disallow to avoid race condition on file descriptors
- Fix tmp files cleanup