### PR TITLE
Add check constraints for container.version_ttl_seconds and blobs.size

### DIFF
--- a/repositories/metadata/postgresql/migrations/sql/0007_ensure_containers_versions_ttl_and_blobs_size.down.sql
+++ b/repositories/metadata/postgresql/migrations/sql/0007_ensure_containers_versions_ttl_and_blobs_size.down.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE blobs
+    DROP CONSTRAINT size_range
+;
+
+ALTER TABLE containers
+    DROP CONSTRAINT version_ttl_seconds_range
+;
+
+COMMIT;

--- a/repositories/metadata/postgresql/migrations/sql/0007_ensure_containers_versions_ttl_and_blobs_size.up.sql
+++ b/repositories/metadata/postgresql/migrations/sql/0007_ensure_containers_versions_ttl_and_blobs_size.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE blobs
+    ADD CONSTRAINT size_range CHECK (size >= 0)
+;
+
+ALTER TABLE containers
+    ADD CONSTRAINT version_ttl_seconds_range CHECK (version_ttl_seconds >= -1)
+;
+
+COMMIT;


### PR DESCRIPTION
To ensure data integrity

Ref: #196 