### PR TITLE
Reduce amount of time provider calls

### DIFF
--- a/repositories/metadata/postgresql/blobs_test.go
+++ b/repositories/metadata/postgresql/blobs_test.go
@@ -11,7 +11,7 @@ func (s *postgreSQLRepositoryTestSuite) TestBlobs() {
 		checksum      = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	)
 
-	s.tp.On("Now").Return("2024-01-02T01:02:03Z").Times(6)
+	s.tp.On("Now").Return("2024-01-02T01:02:03Z").Times(4)
 
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, containerName, -1)
 	s.Require().NoError(err)
@@ -46,7 +46,7 @@ func (s *postgreSQLRepositoryTestSuite) TestBlobs() {
 }
 
 func (s *postgreSQLRepositoryTestSuite) TestGetBlobKeyByObjectErrors() {
-	s.tp.On("Now").Return("2024-01-02T01:02:03Z").Twice()
+	s.tp.On("Now").Return("2024-01-02T01:02:01Z").Once()
 
 	// Nothing exists: container, version, key
 	_, err := s.repo.GetBlobKeyByObject(s.ctx, defaultNamespace, "container", "version", "key")
@@ -81,7 +81,7 @@ func (s *postgreSQLRepositoryTestSuite) TestGetBlobKeyByObjectErrors() {
 }
 
 func (s *postgreSQLRepositoryTestSuite) TestGetBlobByObjectErrors() {
-	s.tp.On("Now").Return("2024-01-02T01:02:03Z").Twice()
+	s.tp.On("Now").Return("2024-01-02T01:02:03Z").Once()
 
 	// Nothing exists: container, version, key
 	_, err := s.repo.GetBlobByObject(s.ctx, defaultNamespace, "container", "version", "key")

--- a/repositories/metadata/postgresql/objects.go
+++ b/repositories/metadata/postgresql/objects.go
@@ -66,6 +66,8 @@ func (r *repository) CreateObject(ctx context.Context, namespace, container, ver
 		return mapSQLErrors(err)
 	}
 
+	objectTimestamp := r.tp().UTC()
+
 	row, err = insertQueryRow(ctx, tx, psql.
 		Insert("object_keys").
 		Columns(
@@ -74,7 +76,7 @@ func (r *repository) CreateObject(ctx context.Context, namespace, container, ver
 		).
 		Values(
 			key,
-			r.tp().UTC(),
+			objectTimestamp,
 		).
 		Suffix("ON CONFLICT (key) DO UPDATE SET key=excluded.key RETURNING id"),
 	)
@@ -99,7 +101,7 @@ func (r *repository) CreateObject(ctx context.Context, namespace, container, ver
 			versionID,
 			okID,
 			blobID,
-			r.tp().UTC(),
+			objectTimestamp,
 		))
 	if err != nil {
 		return mapSQLErrors(err)

--- a/repositories/metadata/postgresql/objects_test.go
+++ b/repositories/metadata/postgresql/objects_test.go
@@ -5,9 +5,9 @@ import "github.com/teran/archived/repositories/metadata"
 func (s *postgreSQLRepositoryTestSuite) TestObjects() {
 	const containerName = "test-container-1"
 
-	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(3)
-	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Times(5)
-	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Times(5)
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(4)
+	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Times(4)
+	// s.tp.On("Now").Return("2024-07-07T10:11:14Z").Times(4)
 
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, containerName, -1)
 	s.Require().NoError(err)
@@ -89,7 +89,7 @@ func (s *postgreSQLRepositoryTestSuite) TestRemapObjectErrors() {
 	s.Require().Equal(metadata.ErrNotFound, err)
 
 	// Remap with not existent key
-	s.tp.On("Now").Return("2024-01-02T01:02:03Z").Twice()
+	s.tp.On("Now").Return("2024-01-02T01:02:03Z").Once()
 
 	versionID, err := s.repo.CreateVersion(s.ctx, defaultNamespace, "container1")
 	s.Require().NoError(err)

--- a/repositories/metadata/postgresql/stats_test.go
+++ b/repositories/metadata/postgresql/stats_test.go
@@ -5,9 +5,20 @@ import "github.com/teran/archived/exporter/models"
 func (s *postgreSQLRepositoryTestSuite) TestCountStats() {
 	const containerName = "test-container-1"
 
-	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(3)
-	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Times(7)
-	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Twice()
+	// CreateContainer (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Once()
+
+	// CreateVersion (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Once()
+
+	// CreateBLOB, 2xCreateObject (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Times(3)
+
+	// CreateVersion (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:15Z").Once()
+
+	// CreateObject (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:16Z").Once()
 
 	// Create container
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, containerName, -1)
@@ -60,14 +71,14 @@ func (s *postgreSQLRepositoryTestSuite) TestCountStats() {
 			{
 				Namespace:     defaultNamespace,
 				ContainerName: "test-container-1",
-				VersionName:   "20240707101112",
+				VersionName:   "20240707101113",
 				IsPublished:   false,
 				ObjectsCount:  2,
 			},
 			{
 				Namespace:     defaultNamespace,
 				ContainerName: "test-container-1",
-				VersionName:   "20240707101113",
+				VersionName:   "20240707101115",
 				IsPublished:   true,
 				ObjectsCount:  1,
 			},
@@ -77,14 +88,14 @@ func (s *postgreSQLRepositoryTestSuite) TestCountStats() {
 			{
 				Namespace:     defaultNamespace,
 				ContainerName: "test-container-1",
-				VersionName:   "20240707101112",
+				VersionName:   "20240707101113",
 				IsPublished:   false,
 				SizeBytes:     20,
 			},
 			{
 				Namespace:     defaultNamespace,
 				ContainerName: "test-container-1",
-				VersionName:   "20240707101113",
+				VersionName:   "20240707101115",
 				IsPublished:   true,
 				SizeBytes:     10,
 			},

--- a/repositories/metadata/postgresql/versions.go
+++ b/repositories/metadata/postgresql/versions.go
@@ -57,7 +57,8 @@ func (r *repository) CreateVersion(ctx context.Context, namespace, container str
 		return "", metadata.ErrNotFound
 	}
 
-	versionID := r.tp().UTC().Format("20060102150405")
+	versionTimestamp := r.tp().UTC()
+	versionID := versionTimestamp.Format("20060102150405")
 
 	_, err = insertQuery(ctx, tx, psql.
 		Insert("versions").
@@ -71,7 +72,7 @@ func (r *repository) CreateVersion(ctx context.Context, namespace, container str
 			containerID,
 			versionID,
 			false,
-			r.tp().UTC(),
+			versionTimestamp,
 		))
 	if err != nil {
 		return "", mapSQLErrors(err)

--- a/repositories/metadata/postgresql/versions_test.go
+++ b/repositories/metadata/postgresql/versions_test.go
@@ -8,8 +8,12 @@ import (
 )
 
 func (s *postgreSQLRepositoryTestSuite) TestVersionsOperations() {
-	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(4)
-	s.tp.On("Now").Return("2024-07-07T11:12:13Z").Times(2)
+	// CreateContainer (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Twice()
+
+	// CreateVersion (created_at) - for each call
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Once()
+	s.tp.On("Now").Return("2024-07-07T11:12:13Z").Once()
 
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, "container1", -1)
 	s.Require().NoError(err)
@@ -45,7 +49,11 @@ func (s *postgreSQLRepositoryTestSuite) TestVersionsOperations() {
 }
 
 func (s *postgreSQLRepositoryTestSuite) TestPublishVersion() {
-	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(3)
+	// CreateContainer (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:10Z").Once()
+
+	// CreateVersion (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Once()
 
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, "container1", -1)
 	s.Require().NoError(err)
@@ -131,9 +139,13 @@ func (s *postgreSQLRepositoryTestSuite) TestListObjectsErrorsNotExistentVersion(
 }
 
 func (s *postgreSQLRepositoryTestSuite) TestVersionsPagination() {
-	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(3)
-	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Times(2)
-	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Times(2)
+	// CreateContainer (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Once()
+
+	// CreateVersion (created_at) - for each call
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Once()
 
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, "container1", -1)
 	s.Require().NoError(err)
@@ -182,11 +194,20 @@ func (s *postgreSQLRepositoryTestSuite) TestVersionsPagination() {
 }
 
 func (s *postgreSQLRepositoryTestSuite) TestDeleteVersion() {
-	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(4)
-	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Times(2)
-	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Times(2)
-	s.tp.On("Now").Return("2024-07-07T10:11:15Z").Times(2)
-	s.tp.On("Now").Return("2024-07-07T10:11:16Z").Times(3)
+	// CreateContainer (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Twice()
+
+	// CreateVersion (created_at) - for each call
+	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:15Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:16Z").Once()
+
+	// CreateBLOB (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:16Z").Once()
+
+	// CreateObject (created_at)
+	s.tp.On("Now").Return("2024-07-07T10:11:16Z").Once()
 
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, "container1", -1)
 	s.Require().NoError(err)
@@ -217,11 +238,11 @@ func (s *postgreSQLRepositoryTestSuite) TestDeleteVersion() {
 	s.Require().Equal([]models.Version{
 		{
 			Name:      version2,
-			CreatedAt: time.Date(2024, 7, 7, 10, 11, 13, 0, time.UTC),
+			CreatedAt: time.Date(2024, 7, 7, 10, 11, 14, 0, time.UTC),
 		},
 		{
 			Name:      version1,
-			CreatedAt: time.Date(2024, 7, 7, 10, 11, 12, 0, time.UTC),
+			CreatedAt: time.Date(2024, 7, 7, 10, 11, 13, 0, time.UTC),
 		},
 	}, versions1)
 
@@ -230,11 +251,11 @@ func (s *postgreSQLRepositoryTestSuite) TestDeleteVersion() {
 	s.Require().Equal([]models.Version{
 		{
 			Name:      version4,
-			CreatedAt: time.Date(2024, 7, 7, 10, 11, 15, 0, time.UTC),
+			CreatedAt: time.Date(2024, 7, 7, 10, 11, 16, 0, time.UTC),
 		},
 		{
 			Name:      version3,
-			CreatedAt: time.Date(2024, 7, 7, 10, 11, 14, 0, time.UTC),
+			CreatedAt: time.Date(2024, 7, 7, 10, 11, 15, 0, time.UTC),
 		},
 	}, versions2)
 
@@ -246,7 +267,7 @@ func (s *postgreSQLRepositoryTestSuite) TestDeleteVersion() {
 	s.Require().Equal([]models.Version{
 		{
 			Name:      version2,
-			CreatedAt: time.Date(2024, 7, 7, 10, 11, 13, 0, time.UTC),
+			CreatedAt: time.Date(2024, 7, 7, 10, 11, 14, 0, time.UTC),
 		},
 	}, versions1)
 
@@ -255,21 +276,21 @@ func (s *postgreSQLRepositoryTestSuite) TestDeleteVersion() {
 	s.Require().Equal([]models.Version{
 		{
 			Name:      version4,
-			CreatedAt: time.Date(2024, 7, 7, 10, 11, 15, 0, time.UTC),
+			CreatedAt: time.Date(2024, 7, 7, 10, 11, 16, 0, time.UTC),
 		},
 		{
 			Name:      version3,
-			CreatedAt: time.Date(2024, 7, 7, 10, 11, 14, 0, time.UTC),
+			CreatedAt: time.Date(2024, 7, 7, 10, 11, 15, 0, time.UTC),
 		},
 	}, versions2)
 }
 
 func (s *postgreSQLRepositoryTestSuite) TestGetLatestPublishedVersionByContainer() {
-	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(4)
-	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Times(2)
-	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Times(2)
-	s.tp.On("Now").Return("2024-07-07T10:11:15Z").Times(2)
-	s.tp.On("Now").Return("2024-07-07T10:11:16Z").Times(2)
+	s.tp.On("Now").Return("2024-07-07T10:11:12Z").Times(3)
+	s.tp.On("Now").Return("2024-07-07T10:11:13Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:14Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:15Z").Once()
+	s.tp.On("Now").Return("2024-07-07T10:11:16Z").Once()
 
 	err := s.repo.CreateContainer(s.ctx, defaultNamespace, "container1", -1)
 	s.Require().NoError(err)


### PR DESCRIPTION
Some repository methods had more then one Now() call which made tests a bit unclear in terms of how many mocks are actually required.

So the change is made to:

- To make tests clear
- Reduce discrepancy between timestamps