### PR TITLE
Wrap lazyblob Reader call into a function

### DIFF
--- a/cli/service/service.go
+++ b/cli/service/service.go
@@ -371,7 +371,12 @@ func (s *service) createObject(ctx context.Context, namespaceName, containerName
 			"url":    url,
 		}).Info("uploading BLOB ...")
 
-		if err := uploadBlob(ctx, url, object.Contents, object.Size); err != nil {
+		rd, err := object.Contents(ctx)
+		if err != nil {
+			return err
+		}
+
+		if err := uploadBlob(ctx, url, rd, object.Size); err != nil {
 			return err
 		}
 	}

--- a/cli/service/source/local/local.go
+++ b/cli/service/source/local/local.go
@@ -114,8 +114,10 @@ func (l *local) Process(ctx context.Context, handler func(ctx context.Context, o
 		defer fp.Close()
 
 		if err := handler(ctx, source.Object{
-			Path:     shortPath,
-			Contents: fp,
+			Path: shortPath,
+			Contents: func(ctx context.Context) (io.Reader, error) {
+				return fp, nil
+			},
 			SHA256:   checksum,
 			Size:     uint64(size),
 			MimeType: mimeType,

--- a/cli/service/source/source.go
+++ b/cli/service/source/source.go
@@ -7,7 +7,7 @@ import (
 
 type Object struct {
 	Path     string
-	Contents io.Reader
+	Contents func(ctx context.Context) (io.Reader, error)
 	SHA256   string
 	Size     uint64
 	MimeType string


### PR DESCRIPTION
This would make it called only when needed by consumer but exactly always when Reader is obtained so will make possible to reduce amount of object downloads performed just to get its MIME type or calculate a checksum.